### PR TITLE
(json) fix dictionary parse error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/nacika-ins/json_flex"
 readme = "README.md"
 keywords = ["json"]
 license = "MIT"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["nacika <nacika.inscatolare@gmail.com>"]
 
 [dependencies]

--- a/src/json_flex.rs
+++ b/src/json_flex.rs
@@ -856,6 +856,7 @@ pub fn decode(text: String) -> Box<JFObject> {
                         }
 
                         s_true = "".to_owned();
+                        d_chain.pop().unwrap();
                         chain.pop().unwrap();
                         last_chain = chain.last().unwrap_or(&' ').to_owned();
                     }
@@ -906,6 +907,7 @@ pub fn decode(text: String) -> Box<JFObject> {
                         }
 
                         s_false = "".to_owned();
+                        d_chain.pop().unwrap();
                         chain.pop().unwrap();
                         last_chain = chain.last().unwrap_or(&' ').to_owned();
                     }
@@ -956,6 +958,7 @@ pub fn decode(text: String) -> Box<JFObject> {
                         }
 
                         s_null = "".to_owned();
+                        d_chain.pop().unwrap();
                         chain.pop().unwrap();
                         last_chain = chain.last().unwrap_or(&' ').to_owned();
                     }
@@ -1005,6 +1008,7 @@ pub fn decode(text: String) -> Box<JFObject> {
 
                         }
                         num = "".to_owned();
+                        d_chain.pop().unwrap();
                         chain.pop().unwrap();
                         last_chain = chain.last().unwrap_or(&' ').to_owned();
                     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -771,6 +771,20 @@ fn default() {
 
     // 79
     // -------------------------------------------------------------------------------
+    println!("--- [ 79 ] -----------------------------------------------------------------");
+    let jf = json_flex::decode(r#"{"str":{"key":"ABC"},"int":{"key":0},"float":{"key":0.1},"map":{"key":{"k":"v"}},"vector":{"key":[0,1,2]},"null":{"key":null},"true":{"key":true},"false":{"key":false},"last":"last"}"#.to_owned());
+    println!("{}", jf.to_json());
+    assert_eq!(jf["str"]["key"].to_json(), r#""ABC""#);
+    assert_eq!(jf["int"]["key"].to_json(), r#"0"#);
+    assert_eq!(jf["float"]["key"].to_json(), r#"0.1"#);
+    assert_eq!(jf["map"]["key"].to_json(), r#"{"k":"v"}"#);
+    assert_eq!(jf["vector"]["key"].to_json(), r#"[0,1,2]"#);
+    assert_eq!(jf["null"]["key"].to_json(), r#"null"#);
+    assert_eq!(jf["true"]["key"].to_json(), r#"true"#);
+    assert_eq!(jf["false"]["key"].to_json(), r#"false"#);
+
+    // 80
+    // -------------------------------------------------------------------------------
     // let mut f = File::open("stream.txt").unwrap();
     // let mut s = String::new();
     // f.read_to_string(&mut s);


### PR DESCRIPTION
This pull request is related to the issue #6 .
I added "d_chain.pop().unwrap();" for true, false, null and dictionary.

Please review this code carefully.
If there is better solution, I will fix pull request.

And, the version info in Cargo.toml is changed to "0.3.3".
If possible, please update the version in crate.io.

Thanks in advance.